### PR TITLE
Fix mistake in suggested profile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ and calling the appropriate functions, but I like this setup in my
 {:user
  {...
   :aliases {"var-graph"
-            ["with-profile" "+clj-usage-graph" "lein" "run"
+            ["with-profile" "+clj-usage-graph" "run"
              "-m" "com.gfredericks.clj-usage-graph/var-graph"]
             "namespace-graph"
-            ["with-profile" "+clj-usage-graph" "lein" "run"
+            ["with-profile" "+clj-usage-graph" "run"
              "-m" "com.gfredericks.clj-usage-graph/namespace-graph"]}}
 
  ;; separate profile so that we only have these deps when we're


### PR DESCRIPTION
On `leiningen` 2.6 at least the above configuration causes the error:

```
'lein' is not a task. See 'lein help'.

Did you mean this?
         clean
Error: <stdin>: syntax error in line 1 near 'Error'
```
